### PR TITLE
cmd/promtool: Create FrostDB block converter

### DIFF
--- a/cmd/promtool/frostdb.go
+++ b/cmd/promtool/frostdb.go
@@ -1,0 +1,147 @@
+package main
+
+import (
+	"context"
+	"sort"
+
+	"github.com/apache/arrow/go/v10/arrow/memory"
+	"github.com/polarsignals/frostdb"
+	"github.com/thanos-io/objstore/providers/filesystem"
+
+	epifrost "github.com/prometheus/prometheus/frostdb"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/prometheus/prometheus/tsdb/chunkenc"
+	"github.com/prometheus/prometheus/tsdb/chunks"
+	tsdb_errors "github.com/prometheus/prometheus/tsdb/errors"
+	"github.com/prometheus/prometheus/tsdb/index"
+)
+
+func convertBlockFrostDB(path, blockID string) error {
+	//f, err := os.Create("frostdb-convert-cpu.prof")
+	//if err != nil {
+	//	return err
+	//}
+	//defer f.Close() // error handling omitted for example
+	//if err := pprof.StartCPUProfile(f); err != nil {
+	//	return err
+	//}
+	//defer pprof.StopCPUProfile()
+
+	tsdb, block, err := openBlock(path, blockID)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		tsdb_errors.NewMulti(err, tsdb.Close()).Err()
+	}()
+
+	ir, err := block.Index()
+	if err != nil {
+		return err
+	}
+	defer ir.Close()
+
+	postingsr, err := ir.Postings(index.AllPostingsKey())
+	if err != nil {
+		return err
+	}
+	chunkr, err := block.Chunks()
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = tsdb_errors.NewMulti(err, chunkr.Close()).Err()
+	}()
+
+	// FrostDB
+
+	bucket, err := filesystem.NewBucket("data-promtool")
+	if err != nil {
+		return err
+	}
+	store, err := frostdb.New(
+		frostdb.WithBucketStorage(bucket),
+	)
+	if err != nil {
+		return err
+	}
+
+	db, err := store.DB(context.Background(), "prometheus")
+	if err != nil {
+		return err
+	}
+	tableSchema, err := epifrost.SchemaMetrics()
+	if err != nil {
+		return err
+	}
+	table, err := db.Table(
+		epifrost.TableMetrics,
+		frostdb.NewTableConfig(tableSchema),
+	)
+	if err != nil {
+		return err
+	}
+
+	chks := []chunks.Meta{}
+	builder := labels.ScratchBuilder{}
+
+	labelNamesMap := map[string]struct{}{}
+	for postingsr.Next() {
+		if err := ir.Series(postingsr.At(), &builder, &chks); err != nil {
+			return err
+		}
+		for name := range builder.Labels().Map() {
+			labelNamesMap[name] = struct{}{}
+		}
+	}
+	if postingsr.Err() != nil {
+		return postingsr.Err()
+	}
+
+	labelNames := make([]string, 0, len(labelNamesMap))
+	for name := range labelNamesMap {
+		labelNames = append(labelNames, name)
+	}
+	sort.Strings(labelNames)
+
+	mem := memory.NewGoAllocator()
+
+	rb := epifrost.NewRecordBuilder(mem, labelNames)
+
+	// Reset the postings reader by creating a new one. Seek doesn't work.
+	postingsr, err = ir.Postings(index.AllPostingsKey())
+	if err != nil {
+		return err
+	}
+	var it chunkenc.Iterator
+	for postingsr.Next() {
+		if err := ir.Series(postingsr.At(), &builder, &chks); err != nil {
+			return err
+		}
+
+		lset := builder.Labels()
+
+		for _, chk := range chks {
+			chk, err := chunkr.Chunk(chk)
+			if err != nil {
+				return err
+			}
+
+			it = chk.Iterator(it)
+			for it.Next() == chunkenc.ValFloat {
+				t, v := it.At()
+				rb.Append(lset, t, v)
+			}
+		}
+	}
+
+	r := rb.NewRecord()
+	defer r.Release()
+
+	_, err = table.InsertRecord(context.Background(), r)
+	if err != nil {
+		return err
+	}
+
+	return store.Close()
+}

--- a/cmd/promtool/main.go
+++ b/cmd/promtool/main.go
@@ -190,6 +190,10 @@ func main() {
 	analyzeLimit := tsdbAnalyzeCmd.Flag("limit", "How many items to show in each list.").Default("20").Int()
 	analyzeRunExtended := tsdbAnalyzeCmd.Flag("extended", "Run extended analysis.").Bool()
 
+	tsdbFrostDBCmd := tsdbCmd.Command("convert", "Convert a Block to a FrostDB parquet file.")
+	tsdbFrostDBAnalyzePath := tsdbFrostDBCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
+	tsdbFrostDBAnalyzeBlockID := tsdbFrostDBCmd.Arg("block id", "Block to analyze (default is the last block).").String()
+
 	tsdbListCmd := tsdbCmd.Command("list", "List tsdb blocks.")
 	listHumanReadable := tsdbListCmd.Flag("human-readable", "Print human readable values.").Short('r').Bool()
 	listPath := tsdbListCmd.Arg("db path", "Database path (default is "+defaultDBPath+").").Default(defaultDBPath).String()
@@ -320,6 +324,9 @@ func main() {
 
 	case tsdbListCmd.FullCommand():
 		os.Exit(checkErr(listBlocks(*listPath, *listHumanReadable)))
+
+	case tsdbFrostDBCmd.FullCommand():
+		os.Exit(checkErr(convertBlockFrostDB(*tsdbFrostDBAnalyzePath, *tsdbFrostDBAnalyzeBlockID)))
 
 	case tsdbDumpCmd.FullCommand():
 		os.Exit(checkErr(dumpSamples(*dumpPath, *dumpMinTime, *dumpMaxTime, *dumpMatch)))

--- a/frostdb/record.go
+++ b/frostdb/record.go
@@ -1,0 +1,66 @@
+package frostdb
+
+import (
+	"github.com/apache/arrow/go/v10/arrow"
+	"github.com/apache/arrow/go/v10/arrow/array"
+	"github.com/apache/arrow/go/v10/arrow/memory"
+
+	"github.com/prometheus/prometheus/model/labels"
+)
+
+type RecordBuilder struct {
+	mem              memory.Allocator
+	labelNames       []string
+	fields           []arrow.Field
+	builders         []*array.BinaryBuilder
+	builderTimestamp *array.Int64Builder
+	builderValue     *array.Float64Builder
+}
+
+func NewRecordBuilder(mem memory.Allocator, labelNames []string) *RecordBuilder {
+	rb := &RecordBuilder{mem: mem, labelNames: labelNames}
+	rb.fields = make([]arrow.Field, 0, len(labelNames)+2)
+	rb.builders = make([]*array.BinaryBuilder, 0, len(labelNames))
+
+	for _, k := range labelNames {
+		rb.fields = append(rb.fields, arrow.Field{Name: "labels." + k, Type: arrow.BinaryTypes.String})
+		rb.builders = append(rb.builders, array.NewBinaryBuilder(rb.mem, arrow.BinaryTypes.String))
+	}
+
+	rb.fields = append(rb.fields, arrow.Field{Name: ColumnTimestamp, Type: arrow.PrimitiveTypes.Int64})
+	rb.builderTimestamp = array.NewInt64Builder(rb.mem)
+
+	rb.fields = append(rb.fields, arrow.Field{Name: ColumnValue, Type: arrow.PrimitiveTypes.Float64})
+	rb.builderValue = array.NewFloat64Builder(rb.mem)
+	return rb
+}
+
+func (rb *RecordBuilder) Append(labels labels.Labels, timestamp int64, value float64) {
+	for i, ln := range rb.labelNames {
+		lv := labels.Get(ln)
+		if lv == "" {
+			rb.builders[i].AppendNull()
+		} else {
+			rb.builders[i].AppendString(lv)
+		}
+	}
+	rb.builderTimestamp.Append(timestamp)
+	rb.builderValue.Append(value)
+}
+
+func (rb *RecordBuilder) NewRecord() arrow.Record {
+	rows := rb.builderValue.Len()
+
+	arrays := make([]arrow.Array, 0, len(rb.labelNames)+2)
+	for _, b := range rb.builders {
+		arrays = append(arrays, b.NewArray())
+		b.Release()
+	}
+	arrays = append(arrays, rb.builderTimestamp.NewArray())
+	arrays = append(arrays, rb.builderValue.NewArray())
+	rb.builderTimestamp.Release()
+	rb.builderValue.Release()
+
+	schema := arrow.NewSchema(rb.fields, nil)
+	return array.NewRecord(schema, arrays, int64(rows))
+}


### PR DESCRIPTION
This adds `promtool tsdb convert ./prometheus/data/ 01GSQXES4A1DGGGAVSV6FF7R6T` as a command. 
It reads in a TSDB block (all float values, ignoring native histograms for now) and after creating an in-memory arrow record stores the data as parquet file.  
